### PR TITLE
fix: :bug: twitter badge links to badge image instead of account

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 I'm a Co-Founder and the CTO of [Widgetbook](https://www.widgetbook.io/) in Bielefeld, Germany.
 
-![Twitter Follow](https://img.shields.io/twitter/follow/jens_hor?label=jens_hor&logo=twitter&style=flat-square)
+[![Twitter Follow](https://img.shields.io/twitter/follow/jens_hor?label=jens_hor&logo=twitter&style=flat-square)](https://twitter.com/jens_hor)
 - 🔭 I’m currently working on the [Widgetbook](https://github.com/widgetbook/widgetbook) and [Open Peeps](https://pub.dev/packages/open_peeps) package.
 - 🧗🏻 I’m currently learning rock climbing
 - 👨🏼‍💻 I’m looking to collaborate on open source projects


### PR DESCRIPTION
- adjusted link

- closes #1 